### PR TITLE
#59-not-edit-foods-if-datetime-over

### DIFF
--- a/app/Http/Controllers/FoodController.php
+++ b/app/Http/Controllers/FoodController.php
@@ -32,7 +32,7 @@ class FoodController extends Controller
         
         $area = $query->first();
         $foods = Food::latest()->where('trading_date', '>=' ,Carbon::today())->where('trading_time', '>=' ,Carbon::now()->toTimeString())->get();
-        $companyFoods = Food::with('bookings.user')->where('user_id', Auth::id())->latest()->get();
+        $companyFoods = Food::with('bookings.user')->where('user_id', Auth::id())->where('trading_date', '>=' ,Carbon::today())->where('trading_time', '>=' ,Carbon::now()->toTimeString())->latest()->get();
         return view('foods.index', compact('foods','companyFoods', 'area', 'keyword'));
 
     }
@@ -125,7 +125,10 @@ class FoodController extends Controller
      */
     public function edit($id)
     {
-        $food = Food::find($id);
+        // if(){
+        //     return redirect()->route('foods.histories')->with('message', '商品の投稿が完了しました。');
+        // }
+        $food = Food::where('user_id', Auth::id())->where('trading_date', '>=' ,Carbon::today())->where('trading_time', '>=' ,Carbon::now()->toTimeString())->find($id);
         return view('foods.edit', compact('food'));
     }
 

--- a/resources/views/foods/index.blade.php
+++ b/resources/views/foods/index.blade.php
@@ -64,6 +64,7 @@
       @include('layouts.flash')
     </div>
   </div>
+  <h5>出品中商品一覧</h5>
   @foreach ($companyFoods  as $companyFood)
   <div class="row justify-content-center">
     <div class="col-md-8">
@@ -106,4 +107,5 @@
   @endif
 </div>
 @endsection
+
 

--- a/resources/views/foods/show.blade.php
+++ b/resources/views/foods/show.blade.php
@@ -119,27 +119,28 @@
 
             <div class="row justify-content-center">
                 <h5>{{ $food->user->name }}その他クーポン</h5>
-                @foreach ($food->user->foods as $companyFood)
-                @if($companyFood->id !== $food->id)
-                <div class="col-md-6 col-xl-3 mb-5 text-center mx-auto">
-                    <a href="{{ route('foods.show',$companyFood->id) }}">
-                        <div class="card">
-                            <img src="{{ $companyFood->image_name }}" class="card-img-top" alt="商品画像">
-                            <div class="card-body">
-                                <h5 class="card-title">商品名：{{ $companyFood->name }}</h5>
-                                <p class="card-text">引取日：{{ $companyFood->trading_date }}</p>
-                                <p class="card-text">引取時間：{{ $companyFood->trading_time }}</p>
-                                <p class="card-text">{{ $companyFood->price }}円→{{ $companyFood->discount_price }}円</p>
-                                <p class="card-text">クーポン{{ $companyFood->coupon }}枚</p>
+                    @foreach ($food->user->foods as $companyFood)
+                        @if($companyFood->id !== $food->id && $companyFood->trading_date >= \Carbon\Carbon::today() && $companyFood->trading_time >= \Carbon\Carbon::now()->toTimeString())
+                            <div class="col-md-6 col-xl-3 mb-5 text-center mx-auto">
+                                <a href="{{ route('foods.show',$companyFood->id) }}">
+                                    <div class="card">
+                                        <img src="{{ $companyFood->image_name }}" class="card-img-top" alt="商品画像">
+                                        <div class="card-body">
+                                            <h5 class="card-title">商品名：{{ $companyFood->name }}</h5>
+                                            <p class="card-text">引取日：{{ $companyFood->trading_date }}</p>
+                                            <p class="card-text">引取時間：{{ $companyFood->trading_time }}</p>
+                                            <p class="card-text">{{ $companyFood->price }}円→{{ $companyFood->discount_price }}円</p>
+                                            <p class="card-text">クーポン{{ $companyFood->coupon }}枚</p>
+                                        </div>
+                                    </div>
+                                </a>
                             </div>
-                        </div>
-                    </a>
-                </div>
-                @endif
-                @endforeach
+                        @endif
+                    @endforeach
             </div>
         </div>
     </div>
 </div>
 @endif
 @endsection
+

--- a/resources/views/users/history.blade.php
+++ b/resources/views/users/history.blade.php
@@ -14,10 +14,12 @@
               </div>
               <div class="col-md-4">
                 <p class="card-text">商品名：{{ $purchaseHistories->name }}</p>
-                <p class="card-text">{{ \Carbon\Carbon::parse($purchaseHistories->updated_at)->format("Y年n月j日") }}</p>
+                <p class="card-text">商品投稿日：{{ \Carbon\Carbon::parse($purchaseHistories->updated_at)->format("Y年n月j日") }}</p>
               </div>
               <div class="col-md-4">
-                <a class="btn btn-primary" href="{{ route('foods.edit', $purchaseHistories->id) }}">商品の編集</a>
+                @if($purchaseHistories->trading_date >= \Carbon\Carbon::today() && $purchaseHistories->trading_time >= \Carbon\Carbon::now()->toTimeString())
+                  <a class="btn btn-primary" href="{{ route('foods.edit', $purchaseHistories->id) }}">商品の編集</a>
+                @endif
                 <a class="btn btn-primary" href="{{ route('foods.duplicate', $purchaseHistories->id) }}">商品を複製して投稿</a>
               </div>
             </div>


### PR DESCRIPTION
# issue

#59

# やったこと
- [ ] 取引日時が過ぎた商品の編集ボタンを非表示にした。
- [ ] 上記のままでは直接URLを入力すれば編集ページに飛べてしまうので飛べないようコントローラーを編集した。

